### PR TITLE
fix(worklet): fixed hardcoding the sample rate in downsampling worklet

### DIFF
--- a/client/src/env.d.ts
+++ b/client/src/env.d.ts
@@ -1,7 +1,1 @@
-interface ImportMetaEnv extends Readonly<Record<string, string>> {
-    readonly DEV: string,
-}
-
-interface ImportMeta {
-    readonly env: ImportMetaEnv
-}
+/// <reference types="vite/client" />

--- a/client/src/utils/recorderWorkletProcessor.js
+++ b/client/src/utils/recorderWorkletProcessor.js
@@ -61,17 +61,18 @@ class RecorderProcessor extends AudioWorkletProcessor {
         const buffer = this._bytesWritten < this.bufferSize
             ? this._buffer.slice(0, this._bytesWritten)
             : this._buffer;
-        const result = this.downsampleBuffer(buffer, 44100, 16000);
+        const result = this.downsampleBuffer(buffer, 16000);
         this.port.postMessage(result);
         this.initBuffer();
     }
 
-    downsampleBuffer(buffer, sampleRate, outSampleRate) {
+    downsampleBuffer(buffer, outSampleRate) {
         if (outSampleRate == sampleRate) {
             return buffer;
         }
         if (outSampleRate > sampleRate) {
-            throw 'downsampling rate show be smaller than original sample rate';
+            console.log('downsampling rate show be smaller than original sample rate');
+            return buffer;
         }
         const sampleRateRatio = sampleRate / outSampleRate;
         const newLength = Math.round(buffer.length / sampleRateRatio);


### PR DESCRIPTION
Currently, we are assuming the sample rate for the audio stream to be always 44100 kHz, which is incorrect. I tested with @abhishekkankani and found that different devices send audio streams at different sampling rates. For example, Mac's microphone sends it 48000 kHz whereas Airpods sends it at 24000 kHz. 

This PR removes those assumptions and links worklet directly in the file instead of hosting it on a CDN using vite magic. 😊